### PR TITLE
Limited CI to the build branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: java
 jdk:
   - oraclejdk8
 
+branches:
+  only:
+    - build
+
 before_script: ant clean
 
 script: ant compile


### PR DESCRIPTION
Every time you push, you are building, and if you commit 5 times for a few small changes, you don't want to build 5 times. So, I'd suggest make a new branch called "build" and only push to it when you make a major change, that way you can use the CI as a way to check that your program actually builds.